### PR TITLE
Fixes for out-of-order dynamic init error

### DIFF
--- a/src/library/labels.cc
+++ b/src/library/labels.cc
@@ -735,32 +735,7 @@ namespace CameraApi {
         {kEdsWhiteBalance_Pasted, "Pasted"}
     };
 
-    std::unordered_map<int, LabelMap> Labels::Option = {
-        {kEdsPropID_AEMode, AEMode},
-        {kEdsPropID_AEModeSelect, AEModeSelect},
-        {kEdsPropID_AFMode, AFMode},
-        {kEdsPropID_BatteryQuality, BatteryQuality},
-        {kEdsPropID_Bracket, Bracket},
-        {kEdsPropID_ColorSpace, ColorSpace},
-        {kEdsPropID_DC_Strobe, DCStrobe},
-        {kEdsPropID_DriveMode, DriveMode},
-        {kEdsPropID_Evf_AFMode, EvfAFMode},
-        {kEdsPropID_Evf_HistogramStatus, EvfHistogramStatus},
-        {kEdsPropID_Evf_OutputDevice, EvfOutputDevice},
-        {kEdsPropID_Evf_WhiteBalance, WhiteBalance},
-        {kEdsPropID_Evf_Zoom, EvfZoom},
-        {kEdsPropID_ImageQuality, ImageQuality},
-        {kEdsPropID_LensBarrelStatus, LensBarrelStatus},
-        {kEdsPropID_LensStatus, LensStatus},
-        {kEdsPropID_MeteringMode, MeteringMode},
-        {kEdsPropID_MirrorLockUpState, MirrorUpStatus},
-        {kEdsPropID_MovieParam, MovieQuality},
-        {kEdsPropID_NoiseReduction, NoiseReduction},
-        {kEdsPropID_RedEye, RedEye},
-        {kEdsPropID_Record, Record},
-        {kEdsPropID_SaveTo, SaveTo},
-        {kEdsPropID_WhiteBalance, WhiteBalance}
-    };
+    std::unordered_map<int, LabelMap> Labels::Option;
 
     LabelMap Labels::Error = {
 
@@ -952,4 +927,36 @@ namespace CameraApi {
         {kEdsCompressQuality_SuperFine, "SuperFine"},
         {kEdsCompressQuality_Unknown, "Unknown"}
     };
+
+    void Labels::Init() {
+        // Defer creation of option map until 'initialization' phase to
+        // prevent out-of-order dynamic initialization error
+        // Note: Called by Option::Init()
+        Labels::Option = {
+            {kEdsPropID_AEMode, AEMode},
+            {kEdsPropID_AEModeSelect, AEModeSelect},
+            {kEdsPropID_AFMode, AFMode},
+            {kEdsPropID_BatteryQuality, BatteryQuality},
+            {kEdsPropID_Bracket, Bracket},
+            {kEdsPropID_ColorSpace, ColorSpace},
+            {kEdsPropID_DC_Strobe, DCStrobe},
+            {kEdsPropID_DriveMode, DriveMode},
+            {kEdsPropID_Evf_AFMode, EvfAFMode},
+            {kEdsPropID_Evf_HistogramStatus, EvfHistogramStatus},
+            {kEdsPropID_Evf_OutputDevice, EvfOutputDevice},
+            {kEdsPropID_Evf_WhiteBalance, WhiteBalance},
+            {kEdsPropID_Evf_Zoom, EvfZoom},
+            {kEdsPropID_ImageQuality, ImageQuality},
+            {kEdsPropID_LensBarrelStatus, LensBarrelStatus},
+            {kEdsPropID_LensStatus, LensStatus},
+            {kEdsPropID_MeteringMode, MeteringMode},
+            {kEdsPropID_MirrorLockUpState, MirrorUpStatus},
+            {kEdsPropID_MovieParam, MovieQuality},
+            {kEdsPropID_NoiseReduction, NoiseReduction},
+            {kEdsPropID_RedEye, RedEye},
+            {kEdsPropID_Record, Record},
+            {kEdsPropID_SaveTo, SaveTo},
+            {kEdsPropID_WhiteBalance, WhiteBalance}
+        };        
+    }
 }

--- a/src/library/labels.h
+++ b/src/library/labels.h
@@ -7,6 +7,8 @@ namespace CameraApi {
 
     class Labels {
         public:
+            static void Init();
+            
             static LabelMap Error;
 
             static LabelMap ObjectEventID;

--- a/src/library/option.cc
+++ b/src/library/option.cc
@@ -169,6 +169,9 @@ namespace CameraApi {
     }
 
     void Option::Init(Napi::Env env, Napi::Object exports) {
+        // Initialize the option map inside the Labels singleton
+        Labels::Init();
+
         Napi::HandleScope scope(env);
 
         std::vector<PropertyDescriptor> properties = {

--- a/src/library/time-zone.cc
+++ b/src/library/time-zone.cc
@@ -65,7 +65,7 @@ namespace CameraApi {
         zone_ = (((1 << 16) - 1) & (value >> (16)));
     }
 
-    std::string TimeZone::GetDifferenceAsOffset(EdsInt32 differenceInMinutes) {
+    std::string TimeZone::GetDifferenceAsOffset(EdsInt16 differenceInMinutes) {
         auto hours = (int)std::floor(differenceInMinutes / 60);
         auto minutes = (int)std::abs(differenceInMinutes - (hours * 60));
         return stringFormat(

--- a/src/library/time-zone.h
+++ b/src/library/time-zone.h
@@ -45,7 +45,7 @@ namespace CameraApi {
 
             Napi::Value Inspect(const Napi::CallbackInfo &info);
 
-            static std::string GetDifferenceAsOffset(EdsInt32 differenceInMinutes);
+            static std::string GetDifferenceAsOffset(EdsInt16 differenceInMinutes);
     };
 }
 

--- a/tests/common/TimeZone.test.ts
+++ b/tests/common/TimeZone.test.ts
@@ -28,11 +28,41 @@ const CommonTimeZoneTests = (api: typeof CameraApi) => {
             test(
                 'TimeZone, -04:00 New York',
                 () => {
-                    const timeZone = new api.TimeZone(0x001B00F0);
-                    expect(timeZone.value).toStrictEqual(0x001B00F0);
-                    expect(timeZone.label).toStrictEqual('+04:00 New York');
+                    const timeZone = new api.TimeZone(0x001BFF10);
+                    expect(timeZone.value).toStrictEqual(0x001BFF10);
+                    expect(timeZone.label).toStrictEqual('-04:00 New York');
                     expect(timeZone.zone).toStrictEqual(27);
-                    expect(timeZone.difference).toStrictEqual(60 * 4);
+                    expect(timeZone.difference).toStrictEqual(60 * -4);
+                }
+            );
+            test(
+                'TimeZone, -06:00 Chicago',
+                () => {
+                    const timeZone = new api.TimeZone(0x001CFE98);
+                    expect(timeZone.value).toStrictEqual(0x001CFE98);
+                    expect(timeZone.label).toStrictEqual('-06:00 Chicago');
+                    expect(timeZone.zone).toStrictEqual(28);
+                    expect(timeZone.difference).toStrictEqual(60 * -6);
+                }
+            );
+            test(
+                'TimeZone, -06:00 Denver',
+                () => {
+                    const timeZone = new api.TimeZone(0x001DFE98);
+                    expect(timeZone.value).toStrictEqual(0x001DFE98);
+                    expect(timeZone.label).toStrictEqual('-06:00 Denver');
+                    expect(timeZone.zone).toStrictEqual(29);
+                    expect(timeZone.difference).toStrictEqual(60 * -6);
+                }
+            );
+            test(
+                'TimeZone, -08:00 Los Angeles',
+                () => {
+                    const timeZone = new api.TimeZone(0x001EFE20);
+                    expect(timeZone.value).toStrictEqual(0x001EFE20);
+                    expect(timeZone.label).toStrictEqual('-08:00 Los Angeles');
+                    expect(timeZone.zone).toStrictEqual(30);
+                    expect(timeZone.difference).toStrictEqual(60 * -8);
                 }
             );
         }


### PR DESCRIPTION
- Attempted to address issue #4 from the original repo
- All tests passing and examples work

Initialization of Labels::Option was moved into an 'init' function.  That init function is called from the 'Option::Init()' function so that it occurs during addOn initialization but after all the other static members have been initialized.