### PR TITLE
add EVF zoom data

### DIFF
--- a/examples/liveview.ts
+++ b/examples/liveview.ts
@@ -57,7 +57,19 @@ try {
         setInterval(
             () => {
                 try {
-                    console.log({image: camera.downloadLiveViewImage().substring(0, 20)});
+                    const liveViewImage = camera.downloadLiveViewImage();
+                    if (liveViewImage) {
+                        const data = liveViewImage.split("|");
+                        const image = data[0];
+                        const evfData = JSON.parse(data[1]);
+                        console.log({ image: image.substring(0, 20) });
+                        console.log({ "EVF Data": evfData });
+                        console.log({
+                            "EVF Zoom Ratio": camera.getProperty(
+                                 CameraProperty.ID.Evf_Zoom
+                            ).value,
+                        });
+                    }
                 } catch (e) {
                     console.log(e);
                 }


### PR DESCRIPTION
Hello, a little quick upgrade that could probably be done even better. However, as a prototype it seems to work fine.
Since the zoom data is in evfImage, it seems reasonable to have it all in one place with the download of the live view image. A neater approach if it were done as an object.... In any case, I think as a starting point is sufficient.

Thanks,
Greg